### PR TITLE
gmsh: pull in python only for bindings

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -15,12 +15,12 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    blas lapack gmm fltk libjpeg zlib opencascade-occt python
+    blas lapack gmm fltk libjpeg zlib opencascade-occt
   ] ++ lib.optionals (!stdenv.isDarwin) [
     libGL libGLU xorg.libXrender xorg.libXcursor xorg.libXfixes
     xorg.libXext xorg.libXft xorg.libXinerama xorg.libX11 xorg.libSM
     xorg.libICE
-  ];
+  ] ++ lib.optionals enablePython [ python ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,7 +1,9 @@
 { lib, stdenv, fetchurl, cmake, blas, lapack, gfortran, gmm, fltk, libjpeg
-, zlib, libGL, libGLU, xorg, opencascade-occt }:
+, zlib, libGL, libGLU, xorg, opencascade-occt
+, python ? null, enablePython ? false }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
+assert enablePython -> (python != null);
 
 stdenv.mkDerivation rec {
   pname = "gmsh";
@@ -13,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    blas lapack gmm fltk libjpeg zlib opencascade-occt
+    blas lapack gmm fltk libjpeg zlib opencascade-occt python
   ] ++ lib.optionals (!stdenv.isDarwin) [
     libGL libGLU xorg.libXrender xorg.libXcursor xorg.libXfixes
     xorg.libXext xorg.libXft xorg.libXinerama xorg.libX11 xorg.libSM
@@ -21,6 +23,12 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  patches = [ ./fix-python.patch ];
+
+  postPatch = ''
+    substituteInPlace api/gmsh.py --subst-var-by LIBPATH ${placeholder "out"}/lib/libgmsh.so
+  '';
 
   # N.B. the shared object is used by bindings
   cmakeFlags = [
@@ -30,6 +38,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake gfortran ];
+
+  postFixup = lib.optionalString enablePython ''
+    mkdir -p $out/lib/python${python.pythonVersion}/site-packages
+    mv $out/lib/gmsh.py $out/lib/python${python.pythonVersion}/site-packages
+    mv $out/lib/*.dist-info $out/lib/python${python.pythonVersion}/site-packages
+  '';
 
   doCheck = true;
 

--- a/pkgs/applications/science/math/gmsh/fix-python.patch
+++ b/pkgs/applications/science/math/gmsh/fix-python.patch
@@ -1,0 +1,50 @@
+diff --git a/api/gmsh.py b/api/gmsh.py
+index 747acb203..02004da5d 100644
+--- a/api/gmsh.py
++++ b/api/gmsh.py
+@@ -44,44 +44,7 @@ moduledir = os.path.dirname(os.path.realpath(__file__))
+ parentdir1 = os.path.dirname(moduledir)
+ parentdir2 = os.path.dirname(parentdir1)
+ 
+-if platform.system() == "Windows":
+-    libname = "gmsh-4.11.dll"
+-elif platform.system() == "Darwin":
+-    libname = "libgmsh.4.11.dylib"
+-else:
+-    libname = "libgmsh.so.4.11"
+-
+-# check if the library is in the same directory as the module...
+-libpath = os.path.join(moduledir, libname)
+-
+-# ... or in the parent directory or its lib or Lib subdirectory
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, "lib", libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir1, "Lib", libname)
+-
+-# ... or in the parent of the parent directory or its lib or Lib subdirectory
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, "lib", libname)
+-if not os.path.exists(libpath):
+-    libpath = os.path.join(parentdir2, "Lib", libname)
+-
+-# if we couldn't find it, use ctype's find_library utility...
+-if not os.path.exists(libpath):
+-    if platform.system() == "Windows":
+-        libpath = find_library("gmsh-4.11")
+-        if not libpath:
+-            libpath = find_library("gmsh")
+-    else:
+-        libpath = find_library("gmsh")
+-
+-# ... and print a warning if everything failed
+-if not os.path.exists(libpath):
+-    print("Warning: could not find Gmsh shared library " + libname)
++libpath = "@LIBPATH@"
+ 
+ lib = CDLL(libpath)
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3807,6 +3807,10 @@ self: super: with self; {
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 
+  gmsh = toPythonModule (callPackage ../applications/science/math/gmsh {
+    enablePython = true;
+  });
+
   gntp = callPackage ../development/python-modules/gntp { };
 
   gnureadline = callPackage ../development/python-modules/gnureadline { };


### PR DESCRIPTION
Otherwise python2 still gets pulled in via `buildInputs` and complains about use of insecure package.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

